### PR TITLE
Scale images by nearest neighbour in HTML render.

### DIFF
--- a/BlockMap-cli/src/main/resources/de/piegames/blockmap/standalone/tiles.css
+++ b/BlockMap-cli/src/main/resources/de/piegames/blockmap/standalone/tiles.css
@@ -13,6 +13,13 @@ a.tile {
 	outline: none;
 	margin: 0;
 	padding: 0;
+	
+	-ms-interpolation-mode: nearest-neighbor;
+	image-rendering: -webkit-optimize-contrast;
+	image-rendering: -webkit-crisp-edges;
+	image-rendering: -moz-crisp-edges;
+	image-rendering: -o-crisp-edges;
+	image-rendering: pixelated;
 }
 a.tile:hover {
 	border: 1px solid rgba(255,255,255,0.5);


### PR DESCRIPTION
This PR adds some CSS that makes images scale by nearest neighbour instead of bilinear in the HTML render. This makes the images more crisp and sharp looking when zoomed in.

This is the difference when zoomed in at 500%. Above is with the current scaling, and below is with nearest neighbour. 

![some_css_can_make_all_the_difference](https://user-images.githubusercontent.com/8590330/66151211-1e63bd00-e617-11e9-9e53-f622bc4486e2.png)
