### PR TITLE
CI: Allow artifact upload to fail

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,5 +40,6 @@ jobs:
       with:
         name: BlockMap-${{ matrix.os }}-${{ github.sha }}
         path: BlockMap-*/build/libs/fat/BlockMap-*
+      continue-on-error: true
     - name: Execute tests
       run: ./gradlew test


### PR DESCRIPTION
As seen recently, sometimes the Github API is not available or throws 500 errors, but that should not affect a build and mark it failing. 

Thus this will enable "continue-on-error" for the upload task, as described in their documentation, found here: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error