### PR TITLE
Fix blurry player skin

### DIFF
--- a/BlockMap-gui/src/main/java/de/piegames/blockmap/gui/decoration/Pin.java
+++ b/BlockMap-gui/src/main/java/de/piegames/blockmap/gui/decoration/Pin.java
@@ -720,9 +720,12 @@ public class Pin {
 
 		private ImageView getSkin(String url) {
 			log.debug("Loading player skin from: " + url);
-			Image image = new Image(url);
+			// Download the image and set the requested size to 64 * 16, as 64 is the original image size and we need to
+			// scale this by 16 to extract the 8 pixels (8 of the original 64, now 8 * 16 pixels) from the scaled image,
+			// to reach 128 pixels in the extracted result.
+			Image image = new Image(url, 64 * 16, 64 * 16, true, false);
 			PixelReader reader = image.getPixelReader();
-			image = new WritableImage(reader, 8, 8, 8, 8);
+			image = new WritableImage(reader, 8 * 16, 8 * 16, 8 * 16, 8 * 16);
 
 			ImageView graphic = new ImageView(image);
 			graphic.setSmooth(false);


### PR DESCRIPTION
This commit fixes the weird blurry textures for player heads, as seen in #48

To fix the blurry images, we first need to set the requested width / height in the image constructor and also set the smoot parameter to false, which can only be set, when using the constructor. 
As we just want a small part of the image (only the head), we need to scale the whole image by 16x, so that we can later extract the head with a resolution of 128 pixels, that will be scaled correctly (pixel-perfect, without smoothing).
The scaling without smoothing, seems to only work this way, as the "smooth" parameter cannot be set/changed when using another constructor/later.
Another option would be sampling the image with the PixelReader and  creating a new Image with the PixelWriter by hand. 

More information can be found here: https://stackoverflow.com/a/16092631